### PR TITLE
Add HPA permissions to operator ClusterRole

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.42
+version: 0.3.0
 
 # This is the version number of the kaspr-operator being deployed. This version number should be
 # incremented whenever there's a new version of kaspr-operator. Versions are not expected to

--- a/charts/operator/templates/010-clusterrole.yaml
+++ b/charts/operator/templates/010-clusterrole.yaml
@@ -71,6 +71,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - "autoscaling"
+  resources:
+    # The operator needs to access and manage horizontal pod autoscalers to enable auto-scaling of Kaspr components
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Grants the operator permissions to manage HorizontalPodAutoscalers by updating the ClusterRole. Bumps chart version to 0.3.0 to reflect this change.