### PR TITLE
Update Operator v0.7.8 (Chart v0.3.5)

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -7,10 +7,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.3.5
 
 # This is the version number of the kaspr-operator being deployed. This version number should be
 # incremented whenever there's a new version of kaspr-operator. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.7.5"
+appVersion: "0.7.8"

--- a/charts/operator/templates/030-deployment.yaml
+++ b/charts/operator/templates/030-deployment.yaml
@@ -54,6 +54,23 @@ spec:
             {{- end }}
             {{- end }}
             - --liveness=http://0.0.0.0:{{.Values.operator.service.port}}/healthz
+          env:
+            {{- if .Values.operator.env.initialMaxReplicas }}
+            - name: INITIAL_MAX_REPLICAS
+              value: "{{ .Values.operator.env.initialMaxReplicas }}"
+            {{- end }}
+            {{- if .Values.operator.env.hpaScaleUpPolicyPodsPerStep }}
+            - name: HPA_SCALE_UP_POLICY_PODS_PER_STEP
+              value: "{{ .Values.operator.env.hpaScaleUpPolicyPodsPerStep }}"
+            {{- end }}
+            {{- if .Values.operator.env.hpaScaleUpPolicyPeriodSeconds }}
+            - name: HPA_SCALE_UP_POLICY_PERIOD_SECONDS
+              value: "{{ .Values.operator.env.hpaScaleUpPolicyPeriodSeconds }}"
+            {{- end }}
+            {{- if .Values.operator.env.statefulsetDeletionTimeoutSeconds }}
+            - name: STATEFULSET_DELETION_TIMEOUT_SECONDS
+              value: "{{ .Values.operator.env.statefulsetDeletionTimeoutSeconds }}"
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.operator.service.port }}

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -60,6 +60,17 @@ operator:
     type: ClusterIP  
     port: 80
 
+  env:
+    # Optional environment variables for the operator
+    # Set initial maximum replicas for HPA (if not specified, operator uses default)
+    initialMaxReplicas: ""
+    # Set HPA scale up policy - number of pods to add per scaling step
+    hpaScaleUpPolicyPodsPerStep: ""
+    # Set HPA scale up policy - period in seconds between scaling steps
+    hpaScaleUpPolicyPeriodSeconds: ""
+    # Set timeout in seconds for StatefulSet deletion operations
+    statefulsetDeletionTimeoutSeconds: ""
+
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Introduces configurable environment variables for initial max replicas, HPA scale up policies, and StatefulSet deletion timeout in the operator deployment. Updates Chart version to 0.3.5 and appVersion to 0.7.8.