### PR TITLE
Add storageclasses access to ClusterRole

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.4
+version: 0.8.5
 
 # This is the version number of the kaspr-operator being deployed. This version number should be
 # incremented whenever there's a new version of kaspr-operator. Versions are not expected to

--- a/charts/operator/templates/015-clusterrole.yaml
+++ b/charts/operator/templates/015-clusterrole.yaml
@@ -31,6 +31,13 @@ rules:
   verbs:
   - watch
   - list
+- apiGroups:
+  - "storage.k8s.io"
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
 
 - apiGroups:
   - "kaspr.io"


### PR DESCRIPTION
Grants the operator ClusterRole permissions to get and list storageclasses in the storage.k8s.io API group. Chart version bumped to 0.8.5 to reflect this change.