### PR TITLE
Add passThrough to publish CRD schema

### DIFF
--- a/charts/operator/crds/kasprtask.crd.yaml
+++ b/charts/operator/crds/kasprtask.crd.yaml
@@ -133,6 +133,9 @@ spec:
                               ack:
                                 type: boolean
                                 description: Wait for acknoledgement from the broker before considering the message sent
+                              passThrough:
+                                type: boolean
+                                description: Preserve the original processor value for downstream pipeline steps after publishing.
                               keySerializer:
                                 type: string
                                 description: Serializer for the key of the message

--- a/charts/operator/crds/kasprwebview.crd.yaml
+++ b/charts/operator/crds/kasprwebview.crd.yaml
@@ -238,6 +238,9 @@ spec:
                               ack:
                                 type: boolean
                                 description: Wait for acknoledgement from the broker before considering the message sent
+                              passThrough:
+                                type: boolean
+                                description: Preserve the original processor value for downstream pipeline steps after publishing.
                               keySerializer:
                                 type: string
                                 description: Serializer for the key of the message


### PR DESCRIPTION
Update KasprTask and KasprWebView CRDs to include a new boolean `passThrough` field under publish settings. This documents and validates the option to preserve the original processor value for downstream pipeline steps after publishing.